### PR TITLE
Chore/repository mismatch

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -36,6 +36,9 @@ tests:
       DeploymentOption: Option1
     regions:
       - us-east-1
+      - us-west-2
+      - eu-west-1
+      - eu-central-1
     
   # VOption2a:
   #   parameters:

--- a/scripts/physical-brownfield-all-options.sh
+++ b/scripts/physical-brownfield-all-options.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -ex
 
 if [[ $# -ne 5 ]] ; then
     echo ""

--- a/scripts/physical-greenfield-option1.sh
+++ b/scripts/physical-greenfield-option1.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -ex
 
 if [[ $# -ne 8 ]] ; then
     echo ""

--- a/scripts/physical-greenfield-option2a.sh
+++ b/scripts/physical-greenfield-option2a.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -ex
 
 if [[ $# -ne 8 ]] ; then
     echo ""

--- a/scripts/physical-greenfield-option2b.sh
+++ b/scripts/physical-greenfield-option2b.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -ex
 
 if [[ $# -ne 7 ]] ; then
     echo ""

--- a/templates/IMC-workload.template.yaml
+++ b/templates/IMC-workload.template.yaml
@@ -183,6 +183,8 @@ Mappings:
       ami: ami-003634241a8fcdec0
     eu-west-1: 
       ami: ami-089cc16f7f08c4457
+    eu-central-1:
+        ami: ami-0d359437d1756caa8
 
 Resources:
   AMCAssetTable:
@@ -1137,6 +1139,20 @@ Resources:
               Fn::GetAtt:
                 - EdgeGroupThingDeviceDefault
                 - thingArn
+  EdgeGroupLoggerDef:
+    Type: 'AWS::Greengrass::LoggerDefinition'
+    Properties:
+      Name: EdgeGroupLoggerDef
+  EdgeGroupLoggerDefVersion:
+    Type: 'AWS::Greengrass::LoggerDefinitionVersion'
+    Properties:
+      LoggerDefinitionId: !Ref EdgeGroupLoggerDef
+      Loggers:
+        - Id: EdgeGroupLoggerDefVersion
+          Type: FileSystem
+          Component: GreengrassSystem
+          Level: DEBUG
+          Space: '128'
   EdgeGroup:
     Type: AWS::Greengrass::Group
     DependsOn: CopyZips
@@ -1167,6 +1183,8 @@ Resources:
         Ref: EdgeGroupFuncDefVersion
       SubscriptionDefinitionVersionArn:
         Ref: EdgeGroupSubDefVersion
+      LoggerDefinitionVersionArn:
+        Ref: EdgeGroupLoggerDefVersion
 
   AMCIncomingResource:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
The cleanup code was meant to be pushed in this repository already, but I think a mistake was made on my part and it was pushed to the private repository that was being used previous to the public release. 

Adding the cleanup, + the ability to deploy in eu-central-1. Taskcat changes included, which tested fine on my end. 