### PR TITLE
TaskCat Test Updates

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -51,7 +51,7 @@ tests:
     parameters:
       DeploymentType: "Virtual"
       EC2KeyPairName: OVERRIDE
-      EdgeDeviceID: tcat-virtual
+      EdgeDeviceID: tcatvirtual
       GreengrassInstanceType: t3.small
       IgnitionInstanceType: t3.large
       PublicSubnet1CIDR: 10.0.128.0/20
@@ -71,7 +71,7 @@ tests:
     parameters:
       DeploymentType: "Physical"
       EC2KeyPairName: OVERRIDE
-      EdgeDeviceID: tcat-physical
+      EdgeDeviceID: tcatphysical
       GreengrassInstanceType: t3.small
       IgnitionInstanceType: t3.large
       PublicSubnet1CIDR: 10.0.128.0/20

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -47,13 +47,11 @@ tests:
       - us-east-1
     template: templates/IMC-main.template.yaml
 
-  ElementUnify:
+  ElementUnifyVirtual:
     parameters:
-      ModelingVendorType: "Element Unify"
-      AMCDriver: "Element Unify"
-      DeploymentType: "Physical"
+      DeploymentType: "Virtual"
       EC2KeyPairName: OVERRIDE
-      EdgeDeviceID: Virtual
+      EdgeDeviceID: tcatVirtual
       GreengrassInstanceType: t3.small
       IgnitionInstanceType: t3.large
       PublicSubnet1CIDR: 10.0.128.0/20
@@ -66,5 +64,26 @@ tests:
       UnifyHostname: OVERRIDE
       UnifyOrgId: OVERRIDE
     regions:
-      - eu-central-1
+      - us-east-1
     template: templates/IMC-unify-main.template.yaml
+
+  ElementUnifyPhysical:
+    parameters:
+      DeploymentType: "Physical"
+      EC2KeyPairName: OVERRIDE
+      EdgeDeviceID: tcatPhysical
+      GreengrassInstanceType: t3.small
+      IgnitionInstanceType: t3.large
+      PublicSubnet1CIDR: 10.0.128.0/20
+      SitewiseMonitorEmail: OVERRIDE
+      UserPublicIP: OVERRIDE
+      VPCCIDR: 10.0.0.0/16
+      VPCTenancy: default
+      UnifyUsername: OVERRIDE
+      UnifyPassword: OVERRIDE
+      UnifyHostname: OVERRIDE
+      UnifyOrgId: OVERRIDE
+    regions:
+      - us-east-1
+    template: templates/IMC-unify-main.template.yaml
+

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -28,7 +28,7 @@ tests:
   #   regions:
   #     - eu-central-1
   #   template: templates/IMC-main.template.yaml
-  
+
   ICLTestPhysical:
     parameters:
       ModelingVendorType: "Asset Model Converter"
@@ -46,12 +46,12 @@ tests:
     regions:
       - us-east-1
     template: templates/IMC-main.template.yaml
-
-  ElementUnifyVirtual:
+  
+  UnifyVirtual:
     parameters:
       DeploymentType: "Virtual"
       EC2KeyPairName: OVERRIDE
-      EdgeDeviceID: tcatVirtual
+      EdgeDeviceID: tcat-virtual
       GreengrassInstanceType: t3.small
       IgnitionInstanceType: t3.large
       PublicSubnet1CIDR: 10.0.128.0/20
@@ -67,11 +67,11 @@ tests:
       - us-east-1
     template: templates/IMC-unify-main.template.yaml
 
-  ElementUnifyPhysical:
+  UnifyPhysical:
     parameters:
       DeploymentType: "Physical"
       EC2KeyPairName: OVERRIDE
-      EdgeDeviceID: tcatPhysical
+      EdgeDeviceID: tcat-physical
       GreengrassInstanceType: t3.small
       IgnitionInstanceType: t3.large
       PublicSubnet1CIDR: 10.0.128.0/20

--- a/templates/IMC-main.template.yaml
+++ b/templates/IMC-main.template.yaml
@@ -171,7 +171,9 @@ Conditions:
   IfPhysical: !Equals
     - !Ref DeploymentType
     - 'Physical'
-
+  IfVirtual: !Equals
+    - !Ref DeploymentType
+    - 'Virtual'
 Resources:
   VPC:
     Type: 'AWS::CloudFormation::Stack'

--- a/templates/IMC-unify-workload.template.yaml
+++ b/templates/IMC-unify-workload.template.yaml
@@ -378,7 +378,10 @@ Resources:
         - !Join
           - ','
           - - !Ref EdgeDeviceID
-        DeleteGreengrass: 'Yes'
+        DeleteGreengrass: !If
+        - IfVirtual
+        - 'Yes'
+        - 'No'
 
   LambdaExecRole:
     Type: AWS::IAM::Role

--- a/templates/IMC-workload.template.yaml
+++ b/templates/IMC-workload.template.yaml
@@ -380,7 +380,11 @@ Resources:
         EdgeDeviceIDs: !Join
         - ','
         - - !Ref EdgeDeviceID
-  
+        DeleteGreengrass: !If
+        - IfVirtual
+        - 'Yes'
+        - 'No'
+
   LambdaExecRole:
     Type: AWS::IAM::Role
     DependsOn: CopyZipsStack


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
1. Fix bug during stack deletion of physical deployment. Only virtual deployments deploy greengrass so when the Physical type is deployed, the StackCleanUp errors out when deleting greengrass. Set DeleteGreenGrass to 'No' when the deployment type is not Virtual.

2. Update taskcat with Unify parameters. Updated to include tests for both Physical and Virtual Unify deployments.

3. Also, fix error in imc-main.template.yaml. The IfVirtual condition was not defined.

Tested creation and deletion with taskcat.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
